### PR TITLE
feat: Implement reusable components for Listening Assessments page and backend integration

### DIFF
--- a/backend/src/routes/user.routes.js
+++ b/backend/src/routes/user.routes.js
@@ -14,6 +14,7 @@ import { verifyJWT } from "../middlewares/auth.middleware.js";
 import {
   addListeningAssessment,
   addReadingAssessment,
+  getListeningAssessments,
   getReadingAssessments,
 } from "../controllers/user.operations.controller.js";
 import { analyzeReadingAssessment } from "../controllers/assessment.analysis.controller.js";
@@ -39,8 +40,10 @@ router
     upload.fields([{ name: "audio", maxCount: 1 }]),
     addListeningAssessment
   );
-//testing
-// router.route("/getOpenAIModels").get(getOpenAIModels);
+
+//secure routes
+router.route("/logout").post(verifyJWT, logoutUser);
+router.route("/getReadingAssessments").get(verifyJWT, getReadingAssessments);
 router
   .route("/analyzeReadingAssessment")
   .post(
@@ -48,7 +51,5 @@ router
     upload.fields([{ name: "audio", maxCount: 1 }]),
     analyzeReadingAssessment
   );
-//secure routes
-router.route("/logout").post(verifyJWT, logoutUser);
-router.route("/getReadingAssessments").get(verifyJWT, getReadingAssessments);
+router.route("/getListeningAssessments").get(verifyJWT, getListeningAssessments);
 export default router;

--- a/frontend/actions/auth.actions.js
+++ b/frontend/actions/auth.actions.js
@@ -131,3 +131,24 @@ export const logoutUser = createAsyncThunk(
     }
   }
 );
+//action/refresh-access-token
+export const refreshAccessToken = async () => {
+  try {
+    const response = await fetch(REFRESH_ACCESSTOKEN_ROUTE, {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    const result = await response.json();
+    if (!response.ok) {
+      throw new Error(
+        result.message || "An error occurred during refresh access token."
+      );
+    }
+    return result;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/frontend/actions/user.actions.js
+++ b/frontend/actions/user.actions.js
@@ -61,28 +61,6 @@ export const verifyUserEmail = createAsyncThunk(
   }
 );
 
-//action/refresh-access-token
-export const refreshAccessToken = async () => {
-  try {
-    const response = await fetch(REFRESH_ACCESSTOKEN_ROUTE, {
-      method: "POST",
-      credentials: "include",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
-    const result = await response.json();
-    if (!response.ok) {
-      throw new Error(
-        result.message || "An error occurred during refresh access token."
-      );
-    }
-    return result;
-  } catch (error) {
-    throw error;
-  }
-};
-
 //action/getReadingAssementes
 export const getAllReadingAssessments = createAsyncThunk(
   "operation/getAllReadingAssesments",
@@ -105,6 +83,35 @@ export const getAllReadingAssessments = createAsyncThunk(
         );
       }
       console.log("getAllReadingAssesments", result);
+      return result;
+    } catch (error) {
+      return rejectWithValue(error.message || "Something went wrong");
+    }
+  }
+);
+
+//action/getAllListeningAssessments
+export const getAllListeningAssessments = createAsyncThunk(
+  "operation/getAllListeningAssessments",
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await fetch(`${BASE_URL}/getListeningAssessments`, {
+        method: "GET",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        throw new Error(
+          result.message ||
+            "An error occurred during fetching listening assesments."
+        );
+      }
+      console.log("getAllListeningAssessments", result);
       return result;
     } catch (error) {
       return rejectWithValue(error.message || "Something went wrong");

--- a/frontend/src/components/AssessmentCard.jsx
+++ b/frontend/src/components/AssessmentCard.jsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { Card, CardContent, CardHeader, Typography } from "@mui/material";
+import { CheckCircle, Clock } from "lucide-react";
+
+const AssessmentCard = ({
+  assessment,
+  index,
+  handleSelectAssessment,
+  logo,
+}) => {
+  const difficultyColor = {
+    easy: "bg-[#aada27]",
+    medium: "bg-[#fdc324]",
+    hard: "bg-[#fc900c]",
+  };
+
+  return (
+    <Card
+      sx={{
+        backgroundColor: assessment.isCompleted ? "grey.200" : "common.white",
+        py: 2,
+        overflow: "hidden",
+        transition: "transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out",
+        "&:hover": {
+          boxShadow: 6,
+          transform: "scale(1.05)",
+        },
+      }}
+      className={`relative ${
+        assessment.isCompleted ? "bg-gray-50" : "bg-white"
+      } py-4 overflow-hidden shadow-md hover:shadow-lg transition-transform transform hover:scale-105`}
+    >
+      <span
+        className={`absolute top-0 right-0 px-2 py-1 text-xs font-semibold rounded-bl-lg text-white ${
+          difficultyColor[assessment.difficulty]
+        }`}
+      >
+        {assessment.difficulty.charAt(0).toUpperCase() +
+          assessment.difficulty.slice(1)}
+      </span>
+
+      {assessment.isCompleted && (
+        <div
+          className={`absolute top-12 left-[-25px] rotate-[-45deg] text-center py-1 px-8 ${
+            parseFloat(assessment.score * 10) < 60
+              ? "bg-red-600"
+              : parseFloat(assessment.score * 10) < 80
+              ? "bg-yellow-600"
+              : "bg-green-600"
+          } shadow-md`}
+          style={{ transformOrigin: "left top" }}
+        >
+          <p className="text-center text-white text-xs font-semibold">
+            {assessment.score * 10}/100
+          </p>
+        </div>
+      )}
+
+      {assessment.isCompleted && (
+        <div
+          className="absolute top-1/2 left-0 w-full transform -translate-y-1/2 bg-[#046f45]/95 text-white text-xs text-center py-1.5 shadow-md"
+          style={{ transformOrigin: "center center", zIndex: 10 }}
+        >
+          <div className="flex items-center justify-center mb-1">
+            <CheckCircle className="w-4 h-4 mr-1" />
+            <div>Completed at</div>
+          </div>
+          <div>
+            {new Date(assessment.completedAt).toLocaleDateString()}{" "}
+            {new Date(assessment.completedAt).toLocaleTimeString()}
+          </div>
+        </div>
+      )}
+
+      <CardHeader
+        className="pb-0"
+        title={
+          <Typography
+            variant="h6"
+            style={{ fontWeight: 600 }}
+            className="text-[#09456a]"
+          >
+            {`Assessment ${index + 1}`}
+          </Typography>
+        }
+      />
+
+      <CardContent className="pt-4">
+        <div className="flex justify-center mb-4">
+          <img
+            src={logo}
+            alt="Logo"
+            width={300}
+            height={80}
+            className="h-20 w-auto bg-transparent"
+          />
+        </div>
+        <div className="flex items-center justify-center text-sm text-[#046f45] mb-2">
+          <Clock className="w-4 h-4 mr-1" />
+          <span>
+            Approx. {formatTime(assessment.evaluationCriteria.timeToComplete)}
+          </span>
+        </div>
+        <button
+          onClick={() => handleSelectAssessment(index)}
+          className="w-full mt-4 transition-all py-2 rounded-md duration-300 hover:scale-105 bg-[#03ccc2] hover:bg-[#02a39a] text-white"
+        >
+          {assessment.isCompleted ? "Retake Assessment" : "Start Assessment"}
+        </button>
+      </CardContent>
+    </Card>
+  );
+};
+
+const formatTime = (time) => {
+  let result = Number(time);
+  if (result < 60) return `${time} seconds`;
+  result = (result / 60).toFixed(2);
+  const finalResult = parseFloat(result);
+  return finalResult > 1 ? `${finalResult} minutes` : `${finalResult} minute`;
+};
+
+export default AssessmentCard;

--- a/frontend/src/components/AssessmentHeader.jsx
+++ b/frontend/src/components/AssessmentHeader.jsx
@@ -1,0 +1,74 @@
+// src/components/AssessmentHeader.jsx
+
+import React from "react";
+import {
+  FormControl,
+  MenuItem,
+  Select,
+  Switch,
+} from "@mui/material";
+
+const AssessmentHeader = ({
+  title,
+  difficulty,
+  showCompleted,
+  onDifficultyChange,
+  onToggleShowCompleted,
+}) => {
+  return (
+    <div className="bg-[#09456a] p-4 rounded-lg mb-6 flex flex-col flex-wrap gap-4 w-full">
+      <h1 className="text-3xl font-bold text-white text-center">{title}</h1>
+      <div className="flex flex-wrap justify-between">
+        <FormControl
+          sx={{
+            width: "220px",
+            "& .MuiOutlinedInput-root": {
+              "&.Mui-focused fieldset": {
+                borderColor: "#02cbc3",
+              },
+            },
+          }}
+        >
+          <Select
+            value={difficulty}
+            onChange={onDifficultyChange}
+            displayEmpty
+            className="w-full bg-white text-gray-700"
+          >
+            <MenuItem value="All">All Difficulties</MenuItem>
+            <MenuItem value="Easy">Easy</MenuItem>
+            <MenuItem value="Medium">Medium</MenuItem>
+            <MenuItem value="Hard">Hard</MenuItem>
+          </Select>
+        </FormControl>
+        <div className="flex items-center space-x-2">
+          <Switch
+            id="show-completed"
+            checked={showCompleted}
+            onChange={onToggleShowCompleted}
+            sx={{
+              padding: 0.8,
+              "& .MuiSwitch-switchBase": {
+                padding: 1.1,
+                "&.Mui-checked": {
+                  color: "#02cbc3",
+                  "& + .MuiSwitch-track": {
+                    backgroundColor: "#02cbc3",
+                  },
+                },
+              },
+              "& .MuiSwitch-track": {
+                backgroundColor: "#ccc",
+              },
+            }}
+          />
+          <label htmlFor="show-completed" className="text-white">
+            Show Completed
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AssessmentHeader;

--- a/frontend/src/components/NoAssessmentFound.jsx
+++ b/frontend/src/components/NoAssessmentFound.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Typography, Box } from "@mui/material"; // Import only what you need from MUI
+import { BookX } from "lucide-react";
+
+export default function NoAssessmentsFound() {
+  return (
+    <div className="backdrop-blur-lg bg-white bg-opacity-10 border border-slate-500 border-opacity-20 rounded-2xl shadow-lg flex flex-col items-center justify-center text-center p-6 w-1/2">
+      <Box className="mb-4">
+        <BookX className="w-16 h-16 text-pink-300" />
+      </Box>
+      <Typography variant="h5" className="text-[#02cbc3]" gutterBottom>
+        No Assessments Found
+      </Typography>
+      <Typography variant="body1" className="text-gray-800" gutterBottom>
+        It seems there are no assessments matching your criteria. Try
+        adjusting your filters or check back later for new additions.
+      </Typography>
+    </div>
+  );
+}

--- a/frontend/src/features/userOperationSlice.js
+++ b/frontend/src/features/userOperationSlice.js
@@ -1,5 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { getAllReadingAssessments } from "../../actions/user.actions.js";
+import {
+  getAllListeningAssessments,
+  getAllReadingAssessments,
+} from "../../actions/user.actions.js";
 
 const initialState = {
   isProcessing: false,
@@ -26,17 +29,35 @@ const userOperationSlice = createSlice({
     builder.addCase(getAllReadingAssessments.pending, (state, _) => {
       state.isProcessing = true;
       state.assessments = null;
+      state.selectedAssessmentIndex = -1;
     });
     builder.addCase(getAllReadingAssessments.fulfilled, (state, action) => {
       state.isProcessing = false;
       state.assessments = action.payload?.data;
+      state.selectedAssessmentIndex = -1;
     });
     builder.addCase(getAllReadingAssessments.rejected, (state, _) => {
       state.isProcessing = false;
       state.assessments = null;
+      state.selectedAssessmentIndex = -1;
     });
 
-   
+    //fetching all listening assessments
+    builder.addCase(getAllListeningAssessments.pending, (state, action) => {
+      state.isProcessing = true;
+      state.assessments = null;
+      state.selectedAssessmentIndex = -1;
+    });
+    builder.addCase(getAllListeningAssessments.fulfilled, (state, action) => {
+      state.isProcessing = false;
+      state.assessments = action.payload?.data;
+      state.selectedAssessmentIndex = -1;
+    });
+    builder.addCase(getAllListeningAssessments.rejected, (state, _) => {
+      state.isProcessing = false;
+      state.assessments = null;
+      state.selectedAssessmentIndex = -1;
+    });
   },
 });
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -25,6 +25,7 @@ import ReadingAssessmentPractice from "./pages/Assessments/reading.assessment.pa
 import FullScreenLayout from "./fullScreenLayout.jsx";
 import { store } from "./app/store.js";
 import { Provider } from "react-redux";
+import ListeningAssessments from "./pages/Practice/listening.page.jsx";
 
 const router = createBrowserRouter(
   createRoutesFromElements(
@@ -48,6 +49,7 @@ const router = createBrowserRouter(
         <Route path="emailverification" element={<EmailVerification />} />
         <Route path="practice" element={<Practice />} />
         <Route path="practice/reading" element={<ReadingAssessments />} />
+        <Route path="practice/listening" element={<ListeningAssessments />} />
         <Route path="takeTest" element={<TakeTest />} />
         <Route path="contact" element={<Contact />} />
         <Route path="feedback" element={<Feedback />} />

--- a/frontend/src/pages/Practice/listening.page.jsx
+++ b/frontend/src/pages/Practice/listening.page.jsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from "react";
+import logo from "/ic_reading.png";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  getAllListeningAssessments,
+  getAllReadingAssessments,
+} from "../../../actions/user.actions";
+import { selectAssessment } from "../../features/userOperationSlice";
+import { useNavigate } from "react-router-dom";
+import AssessmentHeader from "../../components/AssessmentHeader.jsx";
+import AssessmentCard from "../../components/AssessmentCard.jsx";
+import NoAssessmentsFound from "../../components/NoAssessmentFound.jsx";
+
+export default function ListeningAssessments() {
+  const navigate = useNavigate();
+  const [showCompleted, setShowCompleted] = useState(true);
+  const [difficulty, setDifficulty] = useState("All");
+
+  const handleChange = (event) => setDifficulty(event.target.value);
+  const handleToggleCompleted = () => setShowCompleted(!showCompleted);
+
+  const dispatch = useDispatch();
+  const { isProcessing, assessments } = useSelector((state) => state.operation);
+
+  const handleSelectAssessment = (index) => {
+    // dispatch(selectAssessment(index));
+    // navigate(`/practice/reading/assessment/${index + 1}`);
+  };
+
+  useEffect(() => {
+    dispatch(getAllListeningAssessments());
+  }, [dispatch]);
+
+  const filteredAssessments = assessments?.filter(
+    (assessment) =>
+      (difficulty === "All" ||
+        assessment.difficulty === difficulty.toLowerCase()) &&
+      (showCompleted || !assessment.isCompleted)
+  );
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-teal-50 to-blue-100 flex flex-col items-center">
+      {isProcessing ? (
+        <div className="flex justify-center items-center h-full">
+          <p>Loading...</p>
+        </div>
+      ) : (
+        <main className="w-[90%] lg:w-[80%] mx-auto py-6">
+          <AssessmentHeader
+            title="Listening Assessments"
+            difficulty={difficulty}
+            showCompleted={showCompleted}
+            onDifficultyChange={handleChange}
+            onToggleShowCompleted={handleToggleCompleted}
+          />
+
+          {filteredAssessments?.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {filteredAssessments.map((assessment, index) => (
+                <AssessmentCard
+                  key={assessment._id} // Add a unique key here
+                  assessment={assessment}
+                  index={index}
+                  handleSelectAssessment={handleSelectAssessment}
+                  logo={logo}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="flex justify-center mt-10">
+              <NoAssessmentsFound /> {/* Display NoAssessmentsFound in the main content area */}
+            </div>
+          )}
+        </main>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Practice/reading.page.jsx
+++ b/frontend/src/pages/Practice/reading.page.jsx
@@ -1,32 +1,19 @@
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  FormControl,
-  MenuItem,
-  Select,
-  Switch,
-  Typography,
-} from "@mui/material";
-import { Clock } from "lucide-react";
 import React, { useEffect, useState } from "react";
 import logo from "/ic_reading.png";
 import { useDispatch, useSelector } from "react-redux";
 import { getAllReadingAssessments } from "../../../actions/user.actions";
-import {
-  moveNextAssessment,
-  selectAssessment,
-} from "../../features/userOperationSlice";
+import { selectAssessment } from "../../features/userOperationSlice";
 import { useNavigate } from "react-router-dom";
+import AssessmentHeader from "../../components/AssessmentHeader.jsx";
+import AssessmentCard from "../../components/AssessmentCard.jsx";
 
 export default function ReadingAssessments() {
   const navigate = useNavigate();
   const [showCompleted, setShowCompleted] = useState(true);
   const [difficulty, setDifficulty] = useState("All");
 
-  const handleChange = (event) => {
-    setDifficulty(event.target.value);
-  };
+  const handleChange = (event) => setDifficulty(event.target.value);
+  const handleToggleCompleted = () => setShowCompleted(!showCompleted);
 
   const dispatch = useDispatch();
   const { isProcessing, assessments } = useSelector((state) => state.operation);
@@ -36,19 +23,9 @@ export default function ReadingAssessments() {
     navigate(`/practice/reading/assessment/${index + 1}`);
   };
 
-  // useEffect(() => {
-  //   navigate(`/practice/reading/assessment/${selectedAssessmentIndex}`);
-  // }, [handleSelectAssessment]);
-
   useEffect(() => {
     dispatch(getAllReadingAssessments());
   }, [dispatch]);
-
-  const difficultyColor = {
-    easy: "bg-[#aada27]",
-    medium: "bg-[#fdc324]",
-    hard: "bg-[#fc900c]",
-  };
 
   const filteredAssessments = assessments?.filter(
     (assessment) =>
@@ -58,150 +35,39 @@ export default function ReadingAssessments() {
   );
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-teal-50 to-blue-100">
+    <div className="min-h-screen bg-gradient-to-br from-teal-50 to-blue-100 flex flex-col items-center">
       {isProcessing ? (
         <div className="flex justify-center items-center h-full">
           <p>Loading...</p>
         </div>
       ) : (
         <main className="w-[90%] lg:w-[80%] mx-auto py-6">
-          <div className="bg-[#09456a] p-4 rounded-lg mb-6 flex flex-col flex-wrap gap-4 w-full">
-            <h1 className="text-3xl font-bold text-white text-center">
-              Reading Assessments
-            </h1>
-            <div className="flex flex-wrap justify-between">
-              <FormControl
-                sx={{
-                  width: "220px",
-                  "& .MuiOutlinedInput-root": {
-                    "&.Mui-focused fieldset": {
-                      borderColor: "#02cbc3",
-                    },
-                  },
-                }}
-              >
-                <Select
-                  value={difficulty}
-                  onChange={handleChange}
-                  displayEmpty
-                  className="w-full bg-white text-gray-700"
-                >
-                  <MenuItem value="All">All Difficulties</MenuItem>
-                  <MenuItem value="Easy">Easy</MenuItem>
-                  <MenuItem value="Medium">Medium</MenuItem>
-                  <MenuItem value="Hard">Hard</MenuItem>
-                </Select>
-              </FormControl>
-              <div className="flex items-center space-x-2">
-                <Switch
-                  id="show-completed"
-                  checked={showCompleted}
-                  onChange={() => setShowCompleted(!showCompleted)}
-                  sx={{
-                    padding: 0.8,
-                    "& .MuiSwitch-switchBase": {
-                      padding: 1.1,
-                      "&.Mui-checked": {
-                        color: "#02cbc3",
-                        "& + .MuiSwitch-track": {
-                          backgroundColor: "#02cbc3",
-                        },
-                      },
-                    },
-                    "& .MuiSwitch-track": {
-                      backgroundColor: "#ccc",
-                    },
-                  }}
-                />
-                <label htmlFor="show-completed" className="text-white">
-                  Show Completed
-                </label>
-              </div>
-            </div>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {filteredAssessments?.map((assessment, index) => (
-              <Card
-                key={assessment._id}
-                sx={{
-                  backgroundColor: assessment.isCompleted
-                    ? "grey.200"
-                    : "common.white",
-                  py: 2,
-                  overflow: "hidden",
-                  transition:
-                    "transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out",
-                  "&:hover": {
-                    boxShadow: 6,
-                    transform: "scale(1.05)",
-                  },
-                }}
-                className={`relative ${
-                  assessment.isCompleted ? "bg-gray-50" : " bg-white"
-                } py-4 overflow-hidden shadow-md hover:shadow-lg transition-transform transform hover:scale-105`}
-              >
-                <span
-                  className={`absolute top-0 right-0 px-2 py-1 text-xs font-semibold rounded-bl-lg text-white ${
-                    difficultyColor[assessment.difficulty]
-                  }`}
-                >
-                  {assessment.difficulty.charAt(0).toUpperCase() +
-                    assessment.difficulty.slice(1)}
-                </span>
-                {assessment.isCompleted && (
-                  <div
-                    className="absolute top-1/2 left-0 w-full transform -translate-y-1/2 bg-[#046f45]/95 text-white text-xs text-center py-1.5 shadow-lg"
-                    style={{ transformOrigin: "center center", zIndex: 10 }}
-                  >
-                    <div>Completed at</div>
-                    <div>
-                      {new Date(assessment.completedAt).toLocaleDateString()}{" "}
-                      {new Date(assessment.completedAt).toLocaleTimeString()}
-                    </div>
-                  </div>
-                )}
+          <AssessmentHeader
+            title="Listening Assessments"
+            difficulty={difficulty}
+            showCompleted={showCompleted}
+            onDifficultyChange={handleChange}
+            onToggleShowCompleted={handleToggleCompleted}
+          />
 
-                <CardHeader
-                  className="pb-0"
-                  title={
-                    <Typography
-                      variant="h6"
-                      style={{ fontWeight: 600 }}
-                      className="text-[#09456a]"
-                    >
-                      {`Assessment ${index + 1}`}
-                    </Typography>
-                  }
+          {filteredAssessments?.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {filteredAssessments.map((assessment, index) => (
+                <AssessmentCard
+                  key={assessment._id} // Add a unique key here
+                  assessment={assessment}
+                  index={index}
+                  handleSelectAssessment={handleSelectAssessment}
+                  logo={logo}
                 />
-                <CardContent className="pt-4">
-                  <div className="flex justify-center mb-4">
-                    <img
-                      src={logo}
-                      alt="Logo"
-                      width={300}
-                      height={80}
-                      className="h-20 w-auto bg-transparent"
-                    />
-                  </div>
-                  <div className="flex items-center justify-center text-sm text-[#046f45] mb-2">
-                    <Clock className="w-4 h-4 mr-1" />
-                    <span>
-                      Approx. {assessment.evaluationCriteria.timeToComplete}{" "}
-                      Seconds
-                    </span>
-                  </div>
-                  <button
-                    onClick={() => handleSelectAssessment(index)}
-                    className="w-full mt-4 transition-all py-2 rounded-md duration-300 hover:scale-105 bg-[#03ccc2] hover:bg-[#02a39a] text-white"
-                  >
-                    {assessment.isCompleted
-                      ? "Retake Assessment"
-                      : "Start Assessment"}
-                  </button>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex justify-center mt-10">
+              <NoAssessmentsFound />{" "}
+              {/* Display NoAssessmentsFound in the main content area */}
+            </div>
+          )}
         </main>
       )}
     </div>


### PR DESCRIPTION


- Created `AssessmentHeader` component for filtering options (difficulty and completion status).
- Added `AssessmentCard` component for displaying individual assessment details.
- Implemented `NoAssessmentsFound` component to show when no assessments match the filters.
- Updated `ListeningAssessments` page to use reusable components and improve layout structure.
- Placed `NoAssessmentsFound` message outside the grid for better visibility when no assessments are available.
- Integrated `getAllListeningAssessments` backend endpoint to fetch assessments and dispatch in Redux action.

Backend:
- Added `/assessments/listening` endpoint to retrieve listening assessments with specified filters.